### PR TITLE
Add the exclude list in the options of gatsby-plugin-sitemap

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -37,6 +37,7 @@ module.exports = {
         }
       `,
         resolveSiteUrl: () => siteUrl,
+        exclude: ["/en-US", "/en-US/**", "/termsOfUse", "/privacyPolicy"],
       },
     },
     {


### PR DESCRIPTION
This commit removes duplicates due to the locale like `/en-US/**` and useless page links like `/en-US/404`, the terms of use and the privacy policy from `sitemap.xml`.