### PR TITLE
work around fix for react-helmet while SEO data not loaded in the first loading

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -30,6 +30,7 @@ function SEO({ description, lang, meta, title }) {
 
   return (
     <Helmet
+      defer={false}
       htmlAttributes={{
         lang,
       }}


### PR DESCRIPTION
https://v2.gatsbyjs.com/plugins/gatsby-plugin-react-helmet/

I am trying to fix the issue of react-helmet not plugging the SEO data when first loading the page.